### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint and Test (Node ${{ matrix.node-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/hirakinii/ror-api-typescript/security/code-scanning/1](https://github.com/hirakinii/ror-api-typescript/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, the least-privilege baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and read-only CI tasks (install/lint/type-check/test/build). No imports, methods, or dependencies are needed—just YAML changes near the top of the file, between the trigger (`on:`) and `jobs:` (or just after `name:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
